### PR TITLE
Transfer admin

### DIFF
--- a/src/contracts/AttenSysCourse.cairo
+++ b/src/contracts/AttenSysCourse.cairo
@@ -38,6 +38,8 @@ pub trait IAttenSysCourse<TContractState> {
     fn get_course_nft_contract(self: @TContractState, course_identifier: u256) -> ContractAddress;
     fn transfer_admin(ref self: TContractState, new_admin: ContractAddress);
     fn claim_admin_ownership(ref self: TContractState);
+    fn get_admin(self: @TContractState) -> ContractAddress;
+    fn get_new_admin(self: @TContractState) -> ContractAddress;
 }
 
 //Todo, make a count of the total number of users that finished the course.
@@ -345,6 +347,14 @@ mod AttenSysCourse {
 
             self.admin.write(self.intended_new_admin.read());
             self.intended_new_admin.write(self.zero_address());
+        }
+
+        fn get_admin(self: @ContractState) -> ContractAddress {
+            self.admin.read()
+        }
+
+        fn get_new_admin(self: @ContractState) -> ContractAddress {
+            self.intended_new_admin.read()
         }
     }
 

--- a/src/contracts/AttenSysCourse.cairo
+++ b/src/contracts/AttenSysCourse.cairo
@@ -37,6 +37,7 @@ pub trait IAttenSysCourse<TContractState> {
     fn get_creator_info(self: @TContractState, creator: ContractAddress) -> AttenSysCourse::Creator;
     fn get_course_nft_contract(self: @TContractState, course_identifier: u256) -> ContractAddress;
     fn transfer_admin(ref self: TContractState, new_admin: ContractAddress);
+    fn claim_admin_ownership(ref self: TContractState);
 }
 
 //Todo, make a count of the total number of users that finished the course.
@@ -76,6 +77,8 @@ mod AttenSysCourse {
         hash: ClassHash,
         //admin address
         admin: ContractAddress,
+        // address of intended new admin
+        intended_new_admin: ContractAddress,
         //saves nft contract address associated to event
         course_nft_contract_address: Map::<u256, ContractAddress>,
         //tracks all minted nft id minted by events
@@ -334,7 +337,14 @@ mod AttenSysCourse {
             assert(new_admin != self.zero_address(), 'zero address not allowed');
             assert(get_caller_address() == self.admin.read(), 'unauthorized caller');
 
-            self.admin.write(new_admin);
+            self.intended_new_admin.write(new_admin);
+        }
+
+        fn claim_admin_ownership(ref self: ContractState) {
+            assert(get_caller_address() == self.intended_new_admin.read(), 'unauthorized caller');
+
+            self.admin.write(self.intended_new_admin.read());
+            self.intended_new_admin.write(self.zero_address());
         }
     }
 

--- a/src/contracts/AttenSysEvent.cairo
+++ b/src/contracts/AttenSysEvent.cairo
@@ -43,6 +43,8 @@ pub trait IAttenSysEvent<TContractState> {
     fn get_all_events(self: @TContractState) -> Array<AttenSysEvent::EventStruct>;
     fn transfer_admin(ref self: TContractState, new_admin: ContractAddress);
     fn claim_admin_ownership(ref self: TContractState);
+    fn get_admin(self: @TContractState) -> ContractAddress;
+    fn get_new_admin(self: @TContractState) -> ContractAddress;
 }
 
 #[starknet::interface]
@@ -430,6 +432,14 @@ mod AttenSysEvent {
 
             self.admin.write(self.intended_new_admin.read());
             self.intended_new_admin.write(self.zero_address());
+        }
+
+        fn get_admin(self: @ContractState) -> ContractAddress {
+            self.admin.read()
+        }
+
+        fn get_new_admin(self: @ContractState) -> ContractAddress {
+            self.intended_new_admin.read()
         }
     }
 

--- a/src/contracts/AttenSysEvent.cairo
+++ b/src/contracts/AttenSysEvent.cairo
@@ -41,8 +41,6 @@ pub trait IAttenSysEvent<TContractState> {
     ) -> AttenSysEvent::EventStruct;
     fn get_event_nft_contract(self: @TContractState, event_identifier: u256) -> ContractAddress;
     fn get_all_events(self: @TContractState) -> Array<AttenSysEvent::EventStruct>;
-//@todo function to transfer event ownership
-
     fn transfer_admin(ref self: TContractState, new_admin: ContractAddress);
 }
 

--- a/src/contracts/AttenSysEvent.cairo
+++ b/src/contracts/AttenSysEvent.cairo
@@ -42,6 +42,8 @@ pub trait IAttenSysEvent<TContractState> {
     fn get_event_nft_contract(self: @TContractState, event_identifier: u256) -> ContractAddress;
     fn get_all_events(self: @TContractState) -> Array<AttenSysEvent::EventStruct>;
 //@todo function to transfer event ownership
+
+    fn transfer_admin(ref self: TContractState, new_admin: ContractAddress);
 }
 
 #[starknet::interface]
@@ -55,7 +57,7 @@ mod AttenSysEvent {
     use super::IAttenSysNftDispatcherTrait;
     use core::starknet::{
         ContractAddress, get_caller_address, get_block_timestamp, ClassHash,
-        syscalls::deploy_syscall
+        syscalls::deploy_syscall, contract_address_const
     };
     use core::starknet::storage::{
         Map, StoragePathEntry, StoragePointerReadAccess, StoragePointerWriteAccess, Vec,
@@ -414,6 +416,13 @@ mod AttenSysEvent {
             };
             arr
         }
+
+        fn transfer_admin(ref self: ContractState, new_admin: ContractAddress) {
+            assert(new_admin != self.zero_address(), 'zero address not allowed');
+            assert(get_caller_address() == self.admin.read(), 'unauthorized caller');
+
+            self.admin.write(new_admin);
+        }
     }
 
     #[generate_trait]
@@ -441,6 +450,10 @@ mod AttenSysEvent {
                             }
                         }
             }
+        }
+
+        fn zero_address(self: @ContractState) -> ContractAddress {
+            contract_address_const::<0>()
         }
     }
 }

--- a/tests/test_attensys_course.cairo
+++ b/tests/test_attensys_course.cairo
@@ -1,0 +1,128 @@
+use starknet::{ContractAddress, contract_address_const, ClassHash};
+use snforge_std::{
+    declare,
+    ContractClassTrait,
+    start_cheat_caller_address,
+    stop_cheat_caller_address
+};
+
+use attendsys::contracts::AttenSysCourse::{IAttenSysCourseDispatcher, IAttenSysCourseDispatcherTrait};
+
+fn deploy_contract(name: ByteArray, hash: ClassHash) -> ContractAddress {
+    let contract = declare(name).unwrap();
+    let mut constuctor_arg = ArrayTrait::new();
+    let contract_owner_address: ContractAddress = contract_address_const::<'admin'>();
+
+    contract_owner_address.serialize(ref constuctor_arg);
+    hash.serialize(ref constuctor_arg);
+
+    let (contract_address, _) = contract.deploy(@constuctor_arg).unwrap();
+
+    contract_address
+}
+
+fn deploy_nft_contract(name: ByteArray) -> (ContractAddress, ClassHash) {
+    let token_uri: ByteArray = "https://dummy_uri.com/your_id";
+    let name_: ByteArray = "Attensys";
+    let symbol: ByteArray = "ATS";
+
+    let mut constructor_calldata = ArrayTrait::new();
+
+    token_uri.serialize(ref constructor_calldata);
+    name_.serialize(ref constructor_calldata);
+    symbol.serialize(ref constructor_calldata);
+
+    let contract = declare(name).unwrap();
+    let (contract_address, _) = contract.deploy(@constructor_calldata).unwrap();
+
+    (contract_address, contract.class_hash)
+}
+
+#[test]
+fn test_transfer_admin() {
+    let (_nft_contract_address, hash) = deploy_nft_contract("AttenSysNft");
+    let contract_address = deploy_contract("AttenSysCourse", hash);
+
+    let admin: ContractAddress = contract_address_const::<'admin'>();
+    let new_admin: ContractAddress = contract_address_const::<'new_admin'>();
+
+    let attensys_course_contract = IAttenSysCourseDispatcher { contract_address };
+
+    assert(attensys_course_contract.get_admin() == admin, 'wrong admin');
+
+    start_cheat_caller_address(contract_address, admin);
+
+    attensys_course_contract.transfer_admin(new_admin);
+    assert(attensys_course_contract.get_new_admin() == new_admin, 'wrong intended admin');
+
+    stop_cheat_caller_address(contract_address)
+}
+
+#[test]
+fn test_claim_admin() {
+    let (_nft_contract_address, hash) = deploy_nft_contract("AttenSysNft");
+    let contract_address = deploy_contract("AttenSysCourse", hash);
+
+    let admin: ContractAddress = contract_address_const::<'admin'>();
+    let new_admin: ContractAddress = contract_address_const::<'new_admin'>();
+
+    let attensys_course_contract = IAttenSysCourseDispatcher { contract_address };
+
+    assert(attensys_course_contract.get_admin() == admin, 'wrong admin');
+
+    // Admin transfers admin rights to new_admin
+    start_cheat_caller_address(contract_address, admin);
+    attensys_course_contract.transfer_admin(new_admin);
+    assert(attensys_course_contract.get_new_admin() == new_admin, 'wrong intended admin');
+    stop_cheat_caller_address(contract_address);
+
+    // New admin claims admin rights
+    start_cheat_caller_address(contract_address, new_admin);
+    attensys_course_contract.claim_admin_ownership();
+    assert(attensys_course_contract.get_admin() == new_admin, 'admin claim failed');
+    assert(attensys_course_contract.get_new_admin() == contract_address_const::<0>(), 'admin claim failed');
+    stop_cheat_caller_address(contract_address);
+}
+
+#[test]
+#[should_panic(expected: 'unauthorized caller')]
+fn test_transfer_admin_should_panic_for_wrong_admin() {
+    let (_nft_contract_address, hash) = deploy_nft_contract("AttenSysNft");
+    let contract_address = deploy_contract("AttenSysCourse", hash);
+
+    let invalid_admin: ContractAddress = contract_address_const::<'invalid_admin'>();
+    let new_admin: ContractAddress = contract_address_const::<'new_admin'>();
+
+    let attensys_course_contract = IAttenSysCourseDispatcher { contract_address };
+
+
+    // Wrong admin transfers admin rights to new_admin: should revert
+    start_cheat_caller_address(contract_address, invalid_admin);
+    attensys_course_contract.transfer_admin(new_admin);
+    stop_cheat_caller_address(contract_address);
+}
+
+#[test]
+#[should_panic(expected: 'unauthorized caller')]
+fn test_claim_admin_should_panic_for_wrong_new_admin() {
+    let (_nft_contract_address, hash) = deploy_nft_contract("AttenSysNft");
+    let contract_address = deploy_contract("AttenSysCourse", hash);
+
+    let admin: ContractAddress = contract_address_const::<'admin'>();
+    let new_admin: ContractAddress = contract_address_const::<'new_admin'>();
+    let wrong_new_admin: ContractAddress = contract_address_const::<'wrong_new_admin'>();
+
+    let attensys_course_contract = IAttenSysCourseDispatcher { contract_address };
+
+    assert(attensys_course_contract.get_admin() == admin, 'wrong admin');
+
+    // Admin transfers admin rights to new_admin
+    start_cheat_caller_address(contract_address, admin);
+    attensys_course_contract.transfer_admin(new_admin);
+    stop_cheat_caller_address(contract_address);
+
+    // Wrong new admin claims admin rights: should panic
+    start_cheat_caller_address(contract_address, wrong_new_admin);
+    attensys_course_contract.claim_admin_ownership();
+    stop_cheat_caller_address(contract_address);
+}

--- a/tests/test_attensys_event.cairo
+++ b/tests/test_attensys_event.cairo
@@ -1,0 +1,128 @@
+use starknet::{ContractAddress, contract_address_const, ClassHash};
+use snforge_std::{
+    declare,
+    ContractClassTrait,
+    start_cheat_caller_address,
+    stop_cheat_caller_address
+};
+
+use attendsys::contracts::AttenSysEvent::{IAttenSysEventDispatcher, IAttenSysEventDispatcherTrait};
+
+fn deploy_contract(name: ByteArray, hash: ClassHash) -> ContractAddress {
+    let contract = declare(name).unwrap();
+    let mut constuctor_arg = ArrayTrait::new();
+    let contract_owner_address: ContractAddress = contract_address_const::<'admin'>();
+
+    contract_owner_address.serialize(ref constuctor_arg);
+    hash.serialize(ref constuctor_arg);
+
+    let (contract_address, _) = contract.deploy(@constuctor_arg).unwrap();
+
+    contract_address
+}
+
+fn deploy_nft_contract(name: ByteArray) -> (ContractAddress, ClassHash) {
+    let token_uri: ByteArray = "https://dummy_uri.com/your_id";
+    let name_: ByteArray = "Attensys";
+    let symbol: ByteArray = "ATS";
+
+    let mut constructor_calldata = ArrayTrait::new();
+
+    token_uri.serialize(ref constructor_calldata);
+    name_.serialize(ref constructor_calldata);
+    symbol.serialize(ref constructor_calldata);
+
+    let contract = declare(name).unwrap();
+    let (contract_address, _) = contract.deploy(@constructor_calldata).unwrap();
+
+    (contract_address, contract.class_hash)
+}
+
+#[test]
+fn test_transfer_admin() {
+    let (_nft_contract_address, hash) = deploy_nft_contract("AttenSysNft");
+    let contract_address = deploy_contract("AttenSysEvent", hash);
+
+    let admin: ContractAddress = contract_address_const::<'admin'>();
+    let new_admin: ContractAddress = contract_address_const::<'new_admin'>();
+
+    let attensys_event_contract = IAttenSysEventDispatcher { contract_address };
+
+    assert(attensys_event_contract.get_admin() == admin, 'wrong admin');
+
+    start_cheat_caller_address(contract_address, admin);
+
+    attensys_event_contract.transfer_admin(new_admin);
+    assert(attensys_event_contract.get_new_admin() == new_admin, 'wrong intended admin');
+
+    stop_cheat_caller_address(contract_address)
+}
+
+#[test]
+fn test_claim_admin() {
+    let (_nft_contract_address, hash) = deploy_nft_contract("AttenSysNft");
+    let contract_address = deploy_contract("AttenSysEvent", hash);
+
+    let admin: ContractAddress = contract_address_const::<'admin'>();
+    let new_admin: ContractAddress = contract_address_const::<'new_admin'>();
+
+    let attensys_course_contract = IAttenSysEventDispatcher { contract_address };
+
+    assert(attensys_course_contract.get_admin() == admin, 'wrong admin');
+
+    // Admin transfers admin rights to new_admin
+    start_cheat_caller_address(contract_address, admin);
+    attensys_course_contract.transfer_admin(new_admin);
+    assert(attensys_course_contract.get_new_admin() == new_admin, 'wrong intended admin');
+    stop_cheat_caller_address(contract_address);
+
+    // New admin claims admin rights
+    start_cheat_caller_address(contract_address, new_admin);
+    attensys_course_contract.claim_admin_ownership();
+    assert(attensys_course_contract.get_admin() == new_admin, 'admin claim failed');
+    assert(attensys_course_contract.get_new_admin() == contract_address_const::<0>(), 'admin claim failed');
+    stop_cheat_caller_address(contract_address);
+}
+
+#[test]
+#[should_panic(expected: 'unauthorized caller')]
+fn test_transfer_admin_should_panic_for_wrong_admin() {
+    let (_nft_contract_address, hash) = deploy_nft_contract("AttenSysNft");
+    let contract_address = deploy_contract("AttenSysEvent", hash);
+
+    let invalid_admin: ContractAddress = contract_address_const::<'invalid_admin'>();
+    let new_admin: ContractAddress = contract_address_const::<'new_admin'>();
+
+    let attensys_course_contract = IAttenSysEventDispatcher { contract_address };
+
+
+    // Wrong admin transfers admin rights to new_admin: should revert
+    start_cheat_caller_address(contract_address, invalid_admin);
+    attensys_course_contract.transfer_admin(new_admin);
+    stop_cheat_caller_address(contract_address);
+}
+
+#[test]
+#[should_panic(expected: 'unauthorized caller')]
+fn test_claim_admin_should_panic_for_wrong_new_admin() {
+    let (_nft_contract_address, hash) = deploy_nft_contract("AttenSysNft");
+    let contract_address = deploy_contract("AttenSysEvent", hash);
+
+    let admin: ContractAddress = contract_address_const::<'admin'>();
+    let new_admin: ContractAddress = contract_address_const::<'new_admin'>();
+    let wrong_new_admin: ContractAddress = contract_address_const::<'wrong_new_admin'>();
+
+    let attensys_course_contract = IAttenSysEventDispatcher { contract_address };
+
+    assert(attensys_course_contract.get_admin() == admin, 'wrong admin');
+
+    // Admin transfers admin rights to new_admin
+    start_cheat_caller_address(contract_address, admin);
+    attensys_course_contract.transfer_admin(new_admin);
+    stop_cheat_caller_address(contract_address);
+
+    // Wrong new admin claims admin rights: should panic
+    start_cheat_caller_address(contract_address, wrong_new_admin);
+    attensys_course_contract.claim_admin_ownership();
+    stop_cheat_caller_address(contract_address);
+}

--- a/tests/test_contract.cairo
+++ b/tests/test_contract.cairo
@@ -17,10 +17,10 @@ use attendsys::contracts::AttenSysOrg::IAttenSysOrgDispatcher;
 use attendsys::contracts::AttenSysOrg::IAttenSysOrgDispatcherTrait;
 
 
-use attendsys::contracts::AttenSysSponsor::IAttenSysSponsorDispatcher;
-use attendsys::contracts::AttenSysSponsor::IAttenSysSponsorDispatcherTrait;
-use attendsys::contracts::AttenSysSponsor::IERC20Dispatcher;
-use attendsys::contracts::AttenSysSponsor::IERC20DispatcherTrait;
+// use attendsys::contracts::AttenSysSponsor::IAttenSysSponsorDispatcher;
+// use attendsys::contracts::AttenSysSponsor::IAttenSysSponsorDispatcherTrait;
+// use attendsys::contracts::AttenSysSponsor::IERC20Dispatcher;
+// use attendsys::contracts::AttenSysSponsor::IERC20DispatcherTrait;
 
 #[starknet::interface]
 pub trait IERC721<TContractState> {


### PR DESCRIPTION
## Transfer Admin - Closes: https://github.com/AttenSys-Stark/AttenSys/issues/15
- Created and implemented `transfer_admin()` in `AttenSysCourse.cairo`.
- Created and implemented `claim_admin_ownership()` in `AttenSysCourse.cairo`.
- Created `get_admin()` and `get_new_admin()` in `AttenSysCourse.cairo`.
- Implemented test for all the above listed functions in `AttenSysCourse.cairo`.
#
- Created and implemented `transfer_admin()` in `AttenSysEvent.cairo`.
- Created and implemented `claim_admin_ownership()` in `AttenSysEvent.cairo`.
- Created `get_admin()` and `get_new_admin()` in `AttenSysEvent.cairo`.
- Implemented test for all the above listed functions in `AttenSysEvent.cairo`.
