### PR TITLE
Adding new toggle function for event structs status

### DIFF
--- a/src/contracts/AttenSysEvent.cairo
+++ b/src/contracts/AttenSysEvent.cairo
@@ -48,7 +48,7 @@ pub trait IAttenSysEvent<TContractState> {
     fn get_new_admin(self: @TContractState) -> ContractAddress;
     fn sponsor_event(ref self: TContractState, event: ContractAddress, amt: u256, uri: ByteArray);
     fn withdraw_sponsorship_funds(ref self: TContractState, amt: u256);
-    fn toggle_event_suspended_status(ref self: TContractState, event_identifier: u256);
+    fn toggle_event_suspended_status(ref self: TContractState, event_identifier: u256, status: bool);
     fn get_event_suspended_status(self: @TContractState, event_identifier: u256) -> bool;
 }
 
@@ -565,16 +565,13 @@ mod AttenSysEvent {
             self.emit(Withdrawn { amt, event });
         }
 
-        fn toggle_event_suspended_status(ref self: ContractState, event_identifier: u256) {
+        fn toggle_event_suspended_status(ref self: ContractState, event_identifier: u256, status: bool) {
             self.only_admin();
-            let event_details = self.specific_event_with_identifier.entry(event_identifier).read();
-
-            let current_status = event_details.is_suspended;
             self
                 .specific_event_with_identifier
                 .entry(event_identifier)
                 .is_suspended
-                .write(!current_status);
+                .write(status);
         }
 
         fn get_event_suspended_status(self: @ContractState, event_identifier: u256) -> bool {

--- a/src/contracts/AttenSysEvent.cairo
+++ b/src/contracts/AttenSysEvent.cairo
@@ -49,6 +49,7 @@ pub trait IAttenSysEvent<TContractState> {
     fn sponsor_event(ref self: TContractState, event: ContractAddress, amt: u256, uri: ByteArray);
     fn withdraw_sponsorship_funds(ref self: TContractState, amt: u256);
     fn toggle_event_status(ref self: TContractState, event_identifier: u256);
+    fn get_event_suspended_status(self: @TContractState, event_identifier: u256) -> bool;
 }
 
 #[starknet::interface]
@@ -569,6 +570,10 @@ mod AttenSysEvent {
                 .entry(event_identifier)
                 .is_suspended
                 .write(!current_status);
+        }
+
+        fn get_event_suspended_status(self: @ContractState, event_identifier: u256) -> bool {
+            self.specific_event_with_identifier.entry(event_identifier).read().is_suspended
         }
     }
 

--- a/src/contracts/AttenSysEvent.cairo
+++ b/src/contracts/AttenSysEvent.cairo
@@ -253,6 +253,7 @@ mod AttenSysEvent {
 
         fn end_event(ref self: ContractState, event_identifier: u256) {
             //only event owner
+            assert(self.get_event_suspended_status(event_identifier) == false, 'event is suspended');
             self.end_event_(event_identifier);
         }
 
@@ -260,6 +261,7 @@ mod AttenSysEvent {
             //only event owner
             let event_details = self.specific_event_with_identifier.entry(event_identifier).read();
             assert(event_details.event_organizer == get_caller_address(), 'not authorized');
+            assert(event_details.is_suspended == false, 'event is suspended');
             //update attendance_status here
             if self.all_attendance_marked_for_event.entry(event_identifier).len() > 0 {
                 let nft_contract_address = self
@@ -311,6 +313,7 @@ mod AttenSysEvent {
 
         fn mark_attendance(ref self: ContractState, event_identifier: u256) {
             let event_details = self.specific_event_with_identifier.entry(event_identifier).read();
+            assert(event_details.is_suspended == false, 'event is suspended');
             assert(
                 self.registered.entry((get_caller_address(), event_identifier)).read() == true,
                 'not registered',
@@ -351,6 +354,7 @@ mod AttenSysEvent {
 
         fn register_for_event(ref self: ContractState, event_identifier: u256) {
             let event_details = self.specific_event_with_identifier.entry(event_identifier).read();
+            assert(event_details.is_suspended == false, 'event is suspended');
             //can only register once
             assert(
                 self.registered.entry((get_caller_address(), event_identifier)).read() == false,
@@ -441,6 +445,7 @@ mod AttenSysEvent {
 
         fn start_end_reg(ref self: ContractState, reg_stat: bool, event_identifier: u256) {
             let event_details = self.specific_event_with_identifier.entry(event_identifier).read();
+            assert(event_details.is_suspended == false, 'event is suspended');
             //only event owner
             assert(event_details.event_organizer == get_caller_address(), 'not authorized');
             self

--- a/src/contracts/AttenSysEvent.cairo
+++ b/src/contracts/AttenSysEvent.cairo
@@ -48,7 +48,7 @@ pub trait IAttenSysEvent<TContractState> {
     fn get_new_admin(self: @TContractState) -> ContractAddress;
     fn sponsor_event(ref self: TContractState, event: ContractAddress, amt: u256, uri: ByteArray);
     fn withdraw_sponsorship_funds(ref self: TContractState, amt: u256);
-    fn toggle_event_status(ref self: TContractState, event_identifier: u256);
+    fn toggle_event_suspended_status(ref self: TContractState, event_identifier: u256);
     fn get_event_suspended_status(self: @TContractState, event_identifier: u256) -> bool;
 }
 
@@ -560,7 +560,7 @@ mod AttenSysEvent {
             self.emit(Withdrawn { amt, event });
         }
 
-        fn toggle_event_status(ref self: ContractState, event_identifier: u256) {
+        fn toggle_event_suspended_status(ref self: ContractState, event_identifier: u256) {
             self.only_admin();
             let event_details = self.specific_event_with_identifier.entry(event_identifier).read();
 

--- a/tests/test_attensys_event.cairo
+++ b/tests/test_attensys_event.cairo
@@ -192,12 +192,12 @@ fn test_toggle_event_status() {
     assert(event_details.is_suspended == false, 'event is suspended');
     assert(attensys_event_contract.get_event_suspended_status(1) == false, 'event is suspended');
 
-    attensys_event_contract.toggle_event_status(1);
+    attensys_event_contract.toggle_event_suspended_status(1);
     let event_details = attensys_event_contract.get_event_details(1);
     assert(event_details.is_suspended == true, 'event is not suspended');
     assert(attensys_event_contract.get_event_suspended_status(1) == true, 'event is not suspended');
 
-    attensys_event_contract.toggle_event_status(1);
+    attensys_event_contract.toggle_event_suspended_status(1);
     let event_details = attensys_event_contract.get_event_details(1);
     assert(event_details.is_suspended == false, 'event is suspended');
     assert(attensys_event_contract.get_event_suspended_status(1) == false, 'event is suspended');
@@ -235,7 +235,7 @@ fn test_toggle_event_should_panic_for_wrong_admin() {
     let event_details = attensys_event_contract.get_event_details(1);
     assert(event_details.is_suspended == false, 'event is suspended');
 
-    attensys_event_contract.toggle_event_status(1);
+    attensys_event_contract.toggle_event_suspended_status(1);
     let event_details = attensys_event_contract.get_event_details(1);
     assert(event_details.is_suspended == true, 'event is not suspended');
 

--- a/tests/test_attensys_event.cairo
+++ b/tests/test_attensys_event.cairo
@@ -192,12 +192,12 @@ fn test_toggle_event_status() {
     assert(event_details.is_suspended == false, 'event is suspended');
     assert(attensys_event_contract.get_event_suspended_status(1) == false, 'event is suspended');
 
-    attensys_event_contract.toggle_event_suspended_status(1);
+    attensys_event_contract.toggle_event_suspended_status(1, true);
     let event_details = attensys_event_contract.get_event_details(1);
     assert(event_details.is_suspended == true, 'event is not suspended');
     assert(attensys_event_contract.get_event_suspended_status(1) == true, 'event is not suspended');
 
-    attensys_event_contract.toggle_event_suspended_status(1);
+    attensys_event_contract.toggle_event_suspended_status(1, false);
     let event_details = attensys_event_contract.get_event_details(1);
     assert(event_details.is_suspended == false, 'event is suspended');
     assert(attensys_event_contract.get_event_suspended_status(1) == false, 'event is suspended');
@@ -235,7 +235,7 @@ fn test_toggle_event_should_panic_for_wrong_admin() {
     let event_details = attensys_event_contract.get_event_details(1);
     assert(event_details.is_suspended == false, 'event is suspended');
 
-    attensys_event_contract.toggle_event_suspended_status(1);
+    attensys_event_contract.toggle_event_suspended_status(1, true);
     let event_details = attensys_event_contract.get_event_details(1);
     assert(event_details.is_suspended == true, 'event is not suspended');
 

--- a/tests/test_attensys_event.cairo
+++ b/tests/test_attensys_event.cairo
@@ -190,14 +190,17 @@ fn test_toggle_event_status() {
 
     let event_details = attensys_event_contract.get_event_details(1);
     assert(event_details.is_suspended == false, 'event is suspended');
+    assert(attensys_event_contract.get_event_suspended_status(1) == false, 'event is suspended');
 
     attensys_event_contract.toggle_event_status(1);
     let event_details = attensys_event_contract.get_event_details(1);
     assert(event_details.is_suspended == true, 'event is not suspended');
+    assert(attensys_event_contract.get_event_suspended_status(1) == true, 'event is not suspended');
 
     attensys_event_contract.toggle_event_status(1);
     let event_details = attensys_event_contract.get_event_details(1);
     assert(event_details.is_suspended == false, 'event is suspended');
+    assert(attensys_event_contract.get_event_suspended_status(1) == false, 'event is suspended');
 
     stop_cheat_caller_address(contract_address)
 }


### PR DESCRIPTION
# Add Event Status Toggle Functionality

This PR adds the ability for admins to suspend and unsuspend events through a toggle function. Solves #41

## Changes Made

1. **Interface Addition**
   - Added `toggle_event_status` function to the `IAttenSysEvent` trait
   ```cairo
   fn toggle_event_status(ref self: TContractState, event_identifier: u256);
   ```

2. **Implementation Details**
   - Created a new function that toggles an event's suspended status
   - Uses the `is_suspended` field from `EventStruct` to track state
   - Only admin can call this function

3. **Security Changes**
   - Added admin-only check through `only_admin()` helper function

## Testing

- [X] Add tests for toggle functionality
- [X] Test admin-only access
- [X] Verify event suspension works as expected

## Security Considerations

The function is admin-restricted to ensure only authorized users can suspend/unsuspend events.