### PR TITLE
Feat: Integrate STRK Bootcamp Payment Functionality

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-starknet-foundry 0.41.0
+starknet-foundry 0.41.0 --global
 scarb 2.11.3

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-starknet-foundry 0.41.0 --global
+starknet-foundry 0.41.0
 scarb 2.11.3

--- a/src/contracts/org/AttenSysOrg.cairo
+++ b/src/contracts/org/AttenSysOrg.cairo
@@ -289,13 +289,6 @@ pub mod AttenSysOrg {
         WITHDRAWN,
     }
 
-    #[derive(Copy, Drop, Serde, PartialEq, starknet::Store)]
-    pub enum BootCampFundsStatus {
-        #[default]
-        NOT_WITHDRAWN,
-        WITHDRAWN,
-    }
-
     #[derive(Drop, Serde, starknet::Store)]
     pub struct Bootcamp {
         pub bootcamp_id: u64,

--- a/src/contracts/org/AttenSysOrg.cairo
+++ b/src/contracts/org/AttenSysOrg.cairo
@@ -65,9 +65,7 @@ pub trait IAttenSysOrg<TContractState> {
     fn suspend_org_bootcamp(
         ref self: TContractState, org_: ContractAddress, bootcamp_id_: u64, suspend: bool,
     );
-    fn remove_bootcamp(
-        ref self: TContractState, bootcamp_id: u64,
-    );
+    fn remove_bootcamp(ref self: TContractState, bootcamp_id: u64);
     fn get_bootcamp_active_meet_link(
         self: @TContractState, org_: ContractAddress, bootcamp_id: u64,
     ) -> ByteArray;
@@ -160,14 +158,17 @@ pub mod AttenSysOrg {
         Vec, VecTrait,
     };
     use core::starknet::syscalls::deploy_syscall;
-    use core::starknet::{ClassHash, ContractAddress, contract_address_const, get_caller_address, get_contract_address};
+    use core::starknet::{
+        ClassHash, ContractAddress, contract_address_const, get_caller_address,
+        get_contract_address,
+    };
     use openzeppelin::access::ownable::OwnableComponent;
+    use openzeppelin::token::erc20::interface::{IERC20Dispatcher, IERC20DispatcherTrait};
     use openzeppelin::upgrades::UpgradeableComponent;
     use openzeppelin::upgrades::interface::IUpgradeable;
-    use openzeppelin::token::erc20::interface::{IERC20Dispatcher, IERC20DispatcherTrait};
-    use starknet::event::EventEmitter;
     use pragma_lib::abi::{IPragmaABIDispatcher, IPragmaABIDispatcherTrait};
     use pragma_lib::types::{AggregationMode, DataType, PragmaPricesResponse};
+    use starknet::event::EventEmitter;
 
     component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);
     component!(path: UpgradeableComponent, storage: upgradeable, event: UpgradeableEvent);
@@ -184,8 +185,9 @@ pub mod AttenSysOrg {
     const PRAGMA_ORACLE_ADDRESS: felt252 =
         0x36031daa264c24520b11d93af622c848b2499b66b41d611bac95e13cfca131a;
     const KEY: felt252 = 6004514686061859652; // STRK/USD 
-    const ORACLE_PRECISION: u128 = 100_000_000; 
-    const STRK_ADDRESS: felt252 = 0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d;
+    const ORACLE_PRECISION: u128 = 100_000_000;
+    const STRK_ADDRESS: felt252 =
+        0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d;
 
     #[storage]
     struct Storage {
@@ -284,14 +286,14 @@ pub mod AttenSysOrg {
     pub enum BootCampFundsStatus {
         #[default]
         NOT_WITHDRAWN,
-        WITHDRAWN
+        WITHDRAWN,
     }
 
     #[derive(Copy, Drop, Serde, PartialEq, starknet::Store)]
     pub enum BootCampFundsStatus {
         #[default]
         NOT_WITHDRAWN,
-        WITHDRAWN
+        WITHDRAWN,
     }
 
     #[derive(Drop, Serde, starknet::Store)]
@@ -308,7 +310,7 @@ pub mod AttenSysOrg {
         pub active_meet_link: ByteArray,
         pub price: u128,
         pub bootcamp_funds: u128,
-        pub bootcamp_funds_status: BootCampFundsStatus
+        pub bootcamp_funds_status: BootCampFundsStatus,
     }
 
     #[derive(Drop, Serde, starknet::Store)]
@@ -434,7 +436,7 @@ pub mod AttenSysOrg {
         pub nft_uri: ByteArray,
         pub num_of_classes: u256,
         pub bootcamp_ipfs_uri: ByteArray,
-        pub price: u128,    
+        pub price: u128,
     }
 
     #[derive(Drop, starknet::Event)]
@@ -518,7 +520,6 @@ pub mod AttenSysOrg {
     }
 
     #[derive(Drop, starknet::Event)]
-
     pub struct BootcampRemoved {
         pub org_contract_address: ContractAddress,
         pub bootcamp_id: u64,
@@ -920,7 +921,8 @@ pub mod AttenSysOrg {
             let status: bool = self.created_status.entry(org_).read();
             // check org is created
             if status {
-                // let bootcamp: Bootcamp = self.org_to_bootcamps.entry(org_).at(bootcamp_id).read();
+                // let bootcamp: Bootcamp =
+                // self.org_to_bootcamps.entry(org_).at(bootcamp_id).read();
                 assert(
                     !self.bootcamp_suspended.entry(org_).entry(bootcamp_id).read(),
                     'Bootcamp suspended',
@@ -933,25 +935,32 @@ pub mod AttenSysOrg {
                         let mut specific_bootcamp = specific_bootcamp_storage.read();
                         let bootcamp_price = specific_bootcamp.price;
 
-                        student
-                            .num_of_bootcamps_registered_for += 1;
+                        student.num_of_bootcamps_registered_for += 1;
                         student.student_details_uri = student_uri.clone();
 
                         if bootcamp_price > 0 {
                             let student_address = student.address_of_student;
                             let contract_address = get_contract_address();
-                            let strk_bootcamp_price = self.calculate_bootcamp_price_in_strk(bootcamp_price);
-                            let u256_strk_bootcamp_price: u256 = strk_bootcamp_price.try_into().unwrap();
-    
-                            const strk_address: ContractAddress = STRK_ADDRESS.try_into().unwrap();
-                            let strk_dispatcher = IERC20Dispatcher { contract_address: strk_address };
-    
-                            let transfer = strk_dispatcher.transfer_from(student_address, contract_address, u256_strk_bootcamp_price);
-    
-                            assert(transfer, 'Bootcamp Payment Failure');
-                            specific_bootcamp.bootcamp_funds = specific_bootcamp.bootcamp_funds + strk_bootcamp_price;
-                        }
+                            let strk_bootcamp_price = self
+                                .calculate_bootcamp_price_in_strk(bootcamp_price);
+                            let u256_strk_bootcamp_price: u256 = strk_bootcamp_price
+                                .try_into()
+                                .unwrap();
 
+                            const strk_address: ContractAddress = STRK_ADDRESS.try_into().unwrap();
+                            let strk_dispatcher = IERC20Dispatcher {
+                                contract_address: strk_address,
+                            };
+
+                            let transfer = strk_dispatcher
+                                .transfer_from(
+                                    student_address, contract_address, u256_strk_bootcamp_price,
+                                );
+
+                            assert(transfer, 'Bootcamp Payment Failure');
+                            specific_bootcamp.bootcamp_funds = specific_bootcamp.bootcamp_funds
+                                + strk_bootcamp_price;
+                        }
 
                         specific_bootcamp_storage.write(specific_bootcamp);
                         self.student_info.entry(caller).write(student);
@@ -1252,13 +1261,18 @@ pub mod AttenSysOrg {
             }
         }
 
-        fn withdraw_bootcamp_funds(ref self: ContractState, org_: ContractAddress, bootcamp_id: u64) {
+        fn withdraw_bootcamp_funds(
+            ref self: ContractState, org_: ContractAddress, bootcamp_id: u64,
+        ) {
             // Assert here that the caller is the organization
             let caller = get_caller_address();
             let status: bool = self.created_status.entry(caller).read();
             let mut bootcamp: Bootcamp = self.org_to_bootcamps.entry(org_).at(bootcamp_id).read();
             let bootcamp_funds = bootcamp.bootcamp_funds;
-            assert(bootcamp.bootcamp_funds_status != BootCampFundsStatus::WITHDRAWN, 'Already Withdrawn');
+            assert(
+                bootcamp.bootcamp_funds_status != BootCampFundsStatus::WITHDRAWN,
+                'Already Withdrawn',
+            );
             assert(self.bootcamp_ended.entry(org_).entry(bootcamp_id).read(), 'Bootcamp not ended');
             let attensys_org_contract = get_contract_address();
             let strk_address: ContractAddress = STRK_ADDRESS.try_into().unwrap();
@@ -1325,29 +1339,32 @@ pub mod AttenSysOrg {
         fn remove_bootcamp(ref self: ContractState, bootcamp_id: u64) {
             let caller = get_caller_address();
             let status: bool = self.created_status.entry(caller).read();
-            
+
             // Check if caller is an organization
             assert(status, 'Not an organization');
-            
+
             // Check if organization is not suspended
             assert(!self.org_suspended.entry(caller).read(), 'Organization suspended');
-            
+
             // Check if bootcamp exists
             let bootcamp_count = self.org_to_bootcamps.entry(caller).len();
             assert(bootcamp_id < bootcamp_count, 'Bootcamp does not exist');
-            
+
             // Get bootcamp info
             let bootcamp: Bootcamp = self.org_to_bootcamps.entry(caller).at(bootcamp_id).read();
-            
+
             // Check if bootcamp is not suspended
-            assert(!self.bootcamp_suspended.entry(caller).entry(bootcamp_id).read(), 'Bootcamp suspended');
-            
+            assert(
+                !self.bootcamp_suspended.entry(caller).entry(bootcamp_id).read(),
+                'Bootcamp suspended',
+            );
+
             // Check if bootcamp has no participants
             assert(bootcamp.number_of_students == 0, 'Has participants');
-            
+
             // Store bootcamp name for event emission
             let bootcamp_name = bootcamp.bootcamp_name;
-            
+
             // Remove bootcamp from org_to_bootcamps by replacing with last element and popping
             let last_index = bootcamp_count - 1;
             if bootcamp_id != last_index {
@@ -1355,59 +1372,67 @@ pub mod AttenSysOrg {
                 self.org_to_bootcamps.entry(caller).at(bootcamp_id).write(last_bootcamp);
             }
             let _ = self.org_to_bootcamps.entry(caller).pop();
-            
+
             // Remove from all_bootcamps_created
             let all_bootcamps_len = self.all_bootcamps_created.len();
             for i in 0..all_bootcamps_len {
                 let current_bootcamp = self.all_bootcamps_created.at(i).read();
-                if current_bootcamp.address_of_org == caller && current_bootcamp.bootcamp_id == bootcamp_id {
+                if current_bootcamp.address_of_org == caller
+                    && current_bootcamp.bootcamp_id == bootcamp_id {
                     // Replace with last element and pop
                     if i != all_bootcamps_len - 1 {
-                        let last_bootcamp = self.all_bootcamps_created.at(all_bootcamps_len - 1).read();
+                        let last_bootcamp = self
+                            .all_bootcamps_created
+                            .at(all_bootcamps_len - 1)
+                            .read();
                         self.all_bootcamps_created.at(i).write(last_bootcamp);
                     }
                     let _ = self.all_bootcamps_created.pop();
                     break;
                 }
             }
-            
+
             // Clean up related state
             // Remove uploaded videos by clearing the vector
             let videos_len = self.org_to_uploaded_videos_link.entry((caller, bootcamp_id)).len();
             for _ in 0..videos_len {
                 let _ = self.org_to_uploaded_videos_link.entry((caller, bootcamp_id)).pop();
             }
-            
+
             // Remove bootcamp suspension status
             self.bootcamp_suspended.entry(caller).entry(bootcamp_id).write(false);
-            
+
             // Remove bootcamp class data by clearing the vector
             let class_data_len = self.bootcamp_class_data_id.entry((caller, bootcamp_id)).len();
             for _ in 0..class_data_len {
                 let _ = self.bootcamp_class_data_id.entry((caller, bootcamp_id)).pop();
             }
-            
+
             // Remove certified students for this bootcamp by clearing the vector
-            let certified_students_len = self.certified_students_for_bootcamp.entry((caller, bootcamp_id)).len();
+            let certified_students_len = self
+                .certified_students_for_bootcamp
+                .entry((caller, bootcamp_id))
+                .len();
             for _ in 0..certified_students_len {
                 let _ = self.certified_students_for_bootcamp.entry((caller, bootcamp_id)).pop();
             }
-            
+
             // Update organization bootcamp count
             let mut org = self.organization_info.entry(caller).read();
             org.number_of_all_bootcamps -= 1;
             self.organization_info.entry(caller).write(org);
-            
+
             // Emit event
-            self.emit(
-                BootcampRemoved {
-                    org_contract_address: caller,
-                    bootcamp_id: bootcamp_id,
-                    bootcamp_name: bootcamp_name,
-                },
-            );
+            self
+                .emit(
+                    BootcampRemoved {
+                        org_contract_address: caller,
+                        bootcamp_id: bootcamp_id,
+                        bootcamp_name: bootcamp_name,
+                    },
+                );
         }
-        
+
         // read functions
         fn get_all_org_bootcamps(self: @ContractState, org_: ContractAddress) -> Array<Bootcamp> {
             let mut arr_of_all_created_bootcamps = array![];

--- a/tests/test_contract.cairo
+++ b/tests/test_contract.cairo
@@ -2157,7 +2157,7 @@ fn test_remove_bootcamp_success() {
     start_cheat_caller_address(contract_address, owner_address);
     dispatcher.create_org_profile("web3", "ipfs://org");
     dispatcher
-        .create_bootcamp("web3", "bootcamp1", "nft_uri", "NFT", "NFTSYM", 1, "ipfs://bootcamp1");
+        .create_bootcamp("web3", "bootcamp1", "nft_uri", "NFT", "NFTSYM", 1, "ipfs://bootcamp1", 0);
     let org = dispatcher.get_org_info(owner_address);
     assert_eq!(org.number_of_all_bootcamps, 1);
     dispatcher.remove_bootcamp(0);
@@ -2195,7 +2195,7 @@ fn test_remove_bootcamp_non_owner() {
     start_cheat_caller_address(contract_address, owner_address);
     dispatcher.create_org_profile("web3", "ipfs://org");
     dispatcher
-        .create_bootcamp("web3", "bootcamp1", "nft_uri", "NFT", "NFTSYM", 1, "ipfs://bootcamp1");
+        .create_bootcamp("web3", "bootcamp1", "nft_uri", "NFT", "NFTSYM", 1, "ipfs://bootcamp1", 0);
     stop_cheat_caller_address(contract_address);
     start_cheat_caller_address(contract_address, not_owner);
     dispatcher.remove_bootcamp(0);
@@ -2216,7 +2216,7 @@ fn test_remove_bootcamp_with_participants() {
     start_cheat_caller_address(contract_address, owner_address);
     dispatcher.create_org_profile("web3", "ipfs://org");
     dispatcher
-        .create_bootcamp("web3", "bootcamp1", "nft_uri", "NFT", "NFTSYM", 1, "ipfs://bootcamp1");
+        .create_bootcamp("web3", "bootcamp1", "nft_uri", "NFT", "NFTSYM", 1, "ipfs://bootcamp1", 0);
     stop_cheat_caller_address(contract_address);
     start_cheat_caller_address(contract_address, student_address);
     dispatcher.register_for_bootcamp(owner_address, 0, "ipfs://student");
@@ -2239,7 +2239,7 @@ fn test_remove_bootcamp_state_cleanup() {
     start_cheat_caller_address(contract_address, owner_address);
     dispatcher.create_org_profile("web3", "ipfs://org");
     dispatcher
-        .create_bootcamp("web3", "bootcamp1", "nft_uri", "NFT", "NFTSYM", 1, "ipfs://bootcamp1");
+        .create_bootcamp("web3", "bootcamp1", "nft_uri", "NFT", "NFTSYM", 1, "ipfs://bootcamp1", 0);
     dispatcher.add_active_meet_link("meet", 0, false, owner_address);
     dispatcher.remove_bootcamp(0);
     // Should not panic, state should be cleaned

--- a/tests/test_contract.cairo
+++ b/tests/test_contract.cairo
@@ -8,8 +8,8 @@ use attendsys::contracts::event::AttenSysEvent::{
 };
 use attendsys::contracts::mock::ERC20;
 use attendsys::contracts::org::AttenSysOrg::AttenSysOrg::{
-    ActiveMeetLinkAdded, BootCampCreated, BootCampSuspended, BootcampRegistration, BootcampRemoved, ChangeTier,
-    Event, InstructorAddedToOrg, InstructorRemovedFromOrg, OrganizationProfile,
+    ActiveMeetLinkAdded, BootCampCreated, BootCampSuspended, BootcampRegistration, BootcampRemoved,
+    ChangeTier, Event, InstructorAddedToOrg, InstructorRemovedFromOrg, OrganizationProfile,
     OrganizationSuspended, RegistrationApproved, RegistrationDeclined, SetTierPrice, Tier,
 };
 use attendsys::contracts::org::AttenSysOrg::{IAttenSysOrgDispatcher, IAttenSysOrgDispatcherTrait};
@@ -32,7 +32,8 @@ use snforge_std::{
 use starknet::{ClassHash, ContractAddress, contract_address_const};
 
 const STRK_ADDRESS: felt252 = 0x04718f5a0fc34cc1af16a1cdee98ffb20c31f5cd61d6ab07201858f4287c938d;
-const ACTUAL_STRK_HOLDER: felt252 = 0x0168d601Be0C2bDCD09D7568d7Ed711D2A330Cd7488E7539fA66b56144EC998f;
+const ACTUAL_STRK_HOLDER: felt252 =
+    0x0168d601Be0C2bDCD09D7568d7Ed711D2A330Cd7488E7539fA66b56144EC998f;
 
 #[starknet::interface]
 pub trait IERC721<TContractState> {
@@ -769,7 +770,7 @@ fn test_create_free_bootcamp_for_org() {
 
     dispatcher
         .create_bootcamp(
-            org_name, bootcamp_name, token_uri, nft_name, nft_symb, 3, bootcamp_ipfs_uri, 0
+            org_name, bootcamp_name, token_uri, nft_name, nft_symb, 3, bootcamp_ipfs_uri, 0,
         );
     let updatedOrg = dispatcher.get_org_info(owner_address);
     assert_eq!(updatedOrg.number_of_all_bootcamps, 1);
@@ -790,7 +791,7 @@ fn test_create_free_bootcamp_for_org() {
                             nft_uri: nft_symb_cp,
                             num_of_classes: 3,
                             bootcamp_ipfs_uri: bootcamp_ipfs_uri_cp,
-                            price: 0
+                            price: 0,
                         },
                     ),
                 ),
@@ -836,7 +837,7 @@ fn test_create_paid_bootcamp_for_org() {
 
     dispatcher
         .create_bootcamp(
-            org_name, bootcamp_name, token_uri, nft_name, nft_symb, 3, bootcamp_ipfs_uri, 100
+            org_name, bootcamp_name, token_uri, nft_name, nft_symb, 3, bootcamp_ipfs_uri, 100,
         );
     let updatedOrg = dispatcher.get_org_info(owner_address);
     assert_eq!(updatedOrg.number_of_all_bootcamps, 1);
@@ -857,7 +858,7 @@ fn test_create_paid_bootcamp_for_org() {
                             nft_uri: nft_symb_cp,
                             num_of_classes: 3,
                             bootcamp_ipfs_uri: bootcamp_ipfs_uri_cp,
-                            price: 100
+                            price: 100,
                         },
                     ),
                 ),
@@ -896,7 +897,7 @@ fn test_add_active_meet_link_to_bootcamp() {
 
     dispatcher
         .create_bootcamp(
-            org_name, bootcamp_name, token_uri, nft_name, nft_symb, 3, bootcamp_ipfs_uri, 0
+            org_name, bootcamp_name, token_uri, nft_name, nft_symb, 3, bootcamp_ipfs_uri, 0,
         );
 
     // possible to override active meet link.
@@ -956,7 +957,7 @@ fn test_register_for_free_bootcamp() {
 
     dispatcher
         .create_bootcamp(
-            org_name, bootcamp_name, token_uri, nft_name, nft_symb, 3, bootcamp_ipfs_uri, 0
+            org_name, bootcamp_name, token_uri, nft_name, nft_symb, 3, bootcamp_ipfs_uri, 0,
         );
 
     dispatcher.register_for_bootcamp(org_address, 0, token_uri_clone);
@@ -991,7 +992,7 @@ fn test_register_for_paid_bootcamp() {
     let mut spy = spy_events();
     let strk_address: ContractAddress = STRK_ADDRESS.try_into().unwrap();
     let student: felt252 = 0x05Bf9E38B116B37A8249a4cd041D402903a5E8a67C1a99d2D336ac7bd8B4034e;
-    
+
     let owner_address: ContractAddress = contract_address_const::<'owner'>();
     let instructor_address: ContractAddress = contract_address_const::<'instructor'>();
     let instructor_address_cp = instructor_address.clone();
@@ -1015,7 +1016,7 @@ fn test_register_for_paid_bootcamp() {
 
     dispatcher
         .create_bootcamp(
-            org_name, bootcamp_name, token_uri, nft_name, nft_symb, 3, bootcamp_ipfs_uri, 10
+            org_name, bootcamp_name, token_uri, nft_name, nft_symb, 3, bootcamp_ipfs_uri, 10,
         );
     stop_cheat_caller_address(contract_address);
 
@@ -1030,7 +1031,7 @@ fn test_register_for_paid_bootcamp() {
     stop_cheat_caller_address(strk_address);
 
     start_cheat_caller_address(contract_address, student.try_into().unwrap());
-    
+
     println!("I got here, just before payment");
     dispatcher.register_for_bootcamp(org_address, 0, token_uri_clone);
     println!("I got here, just after payment");
@@ -1038,7 +1039,7 @@ fn test_register_for_paid_bootcamp() {
     println!("contract balance after purchase: {}", second_balance);
 
     stop_cheat_caller_address(contract_address);
-    
+
     start_cheat_caller_address(contract_address, owner_address);
     let all_request = dispatcher.get_all_registration_request(owner_address);
     let status: u8 = *all_request[0].status;
@@ -1090,7 +1091,7 @@ fn test_approve_registration() {
     let nft_symb: ByteArray = "CAO";
     dispatcher
         .create_bootcamp(
-            org_name, bootcamp_name, token_uri, nft_name, nft_symb, 3, bootcamp_ipfs_uri, 0
+            org_name, bootcamp_name, token_uri, nft_name, nft_symb, 3, bootcamp_ipfs_uri, 0,
         );
     stop_cheat_caller_address(contract_address);
 
@@ -1186,7 +1187,7 @@ fn test_withdraw_bootcamp_funds() {
     let nft_symb: ByteArray = "CAO";
     dispatcher
         .create_bootcamp(
-            org_name, bootcamp_name, token_uri, nft_name, nft_symb, 3, bootcamp_ipfs_uri, 10
+            org_name, bootcamp_name, token_uri, nft_name, nft_symb, 3, bootcamp_ipfs_uri, 10,
         );
     stop_cheat_caller_address(contract_address);
 
@@ -1247,7 +1248,7 @@ fn test_withdraw_bootcamp_funds() {
     let get_cert_stat_student2 = dispatcher
         .get_bootcamp_certification_status(owner_address, 0, student2_address);
     assert(get_cert_stat_student2, 'incorrect status');
-    
+
     let bootcamps = dispatcher.get_all_org_bootcamps(owner_address);
     let the_bootcamp = bootcamps[0];
     let bootcamp_funds = the_bootcamp.bootcamp_funds;
@@ -1269,7 +1270,6 @@ fn test_withdraw_bootcamp_funds() {
                 ),
             ],
         );
-
 }
 
 
@@ -1307,7 +1307,7 @@ fn test_decline_registration2() {
     let nft_symb: ByteArray = "CAO";
     dispatcher
         .create_bootcamp(
-            org_name, bootcamp_name, token_uri, nft_name, nft_symb, 3, bootcamp_ipfs_uri, 0
+            org_name, bootcamp_name, token_uri, nft_name, nft_symb, 3, bootcamp_ipfs_uri, 0,
         );
     stop_cheat_caller_address(contract_address);
 
@@ -1373,7 +1373,7 @@ fn test_decline_registration() {
     let nft_symb: ByteArray = "CAO";
     dispatcher
         .create_bootcamp(
-            org_name, bootcamp_name, token_uri, nft_name, nft_symb, 3, bootcamp_ipfs_uri, 0
+            org_name, bootcamp_name, token_uri, nft_name, nft_symb, 3, bootcamp_ipfs_uri, 0,
         );
     stop_cheat_caller_address(contract_address);
 
@@ -1979,7 +1979,7 @@ fn test_suspend_bootcamp_for_org() {
 
     dispatcher
         .create_bootcamp(
-            org_name, bootcamp_name, token_uri, nft_name, nft_symb, 3, bootcamp_ipfs_uri, 0
+            org_name, bootcamp_name, token_uri, nft_name, nft_symb, 3, bootcamp_ipfs_uri, 0,
         );
     let updatedOrg = dispatcher.get_org_info(owner_address);
     assert_eq!(updatedOrg.number_of_all_bootcamps, 1);
@@ -2052,7 +2052,7 @@ fn test_unsuspend_bootcamp_for_org() {
 
     dispatcher
         .create_bootcamp(
-            org_name, bootcamp_name, token_uri, nft_name, nft_symb, 3, bootcamp_ipfs_uri, 0
+            org_name, bootcamp_name, token_uri, nft_name, nft_symb, 3, bootcamp_ipfs_uri, 0,
         );
     let updatedOrg = dispatcher.get_org_info(owner_address);
     assert_eq!(updatedOrg.number_of_all_bootcamps, 1);
@@ -2131,7 +2131,7 @@ fn test_suspend_bootcamp_for_org_panic() {
 
     dispatcher
         .create_bootcamp(
-            org_name, bootcamp_name, token_uri, nft_name, nft_symb, 3, bootcamp_ipfs_uri, 0
+            org_name, bootcamp_name, token_uri, nft_name, nft_symb, 3, bootcamp_ipfs_uri, 0,
         );
     let updatedOrg = dispatcher.get_org_info(owner_address);
     assert_eq!(updatedOrg.number_of_all_bootcamps, 1);
@@ -2156,26 +2156,28 @@ fn test_remove_bootcamp_success() {
     let mut spy = spy_events();
     start_cheat_caller_address(contract_address, owner_address);
     dispatcher.create_org_profile("web3", "ipfs://org");
-    dispatcher.create_bootcamp(
-        "web3", "bootcamp1", "nft_uri", "NFT", "NFTSYM", 1, "ipfs://bootcamp1"
-    );
+    dispatcher
+        .create_bootcamp("web3", "bootcamp1", "nft_uri", "NFT", "NFTSYM", 1, "ipfs://bootcamp1");
     let org = dispatcher.get_org_info(owner_address);
     assert_eq!(org.number_of_all_bootcamps, 1);
     dispatcher.remove_bootcamp(0);
     let org = dispatcher.get_org_info(owner_address);
     assert_eq!(org.number_of_all_bootcamps, 0);
-    spy.assert_emitted(@array![
-        (
-            contract_address,
-            Event::BootcampRemoved(
-                BootcampRemoved {
-                    org_contract_address: owner_address,
-                    bootcamp_id: 0,
-                    bootcamp_name: "bootcamp1",
-                }
-            ),
-        ),
-    ]);
+    spy
+        .assert_emitted(
+            @array![
+                (
+                    contract_address,
+                    Event::BootcampRemoved(
+                        BootcampRemoved {
+                            org_contract_address: owner_address,
+                            bootcamp_id: 0,
+                            bootcamp_name: "bootcamp1",
+                        },
+                    ),
+                ),
+            ],
+        );
 }
 
 #[test]
@@ -2192,9 +2194,8 @@ fn test_remove_bootcamp_non_owner() {
     let dispatcher = IAttenSysOrgDispatcher { contract_address };
     start_cheat_caller_address(contract_address, owner_address);
     dispatcher.create_org_profile("web3", "ipfs://org");
-    dispatcher.create_bootcamp(
-        "web3", "bootcamp1", "nft_uri", "NFT", "NFTSYM", 1, "ipfs://bootcamp1"
-    );
+    dispatcher
+        .create_bootcamp("web3", "bootcamp1", "nft_uri", "NFT", "NFTSYM", 1, "ipfs://bootcamp1");
     stop_cheat_caller_address(contract_address);
     start_cheat_caller_address(contract_address, not_owner);
     dispatcher.remove_bootcamp(0);
@@ -2214,9 +2215,8 @@ fn test_remove_bootcamp_with_participants() {
     let dispatcher = IAttenSysOrgDispatcher { contract_address };
     start_cheat_caller_address(contract_address, owner_address);
     dispatcher.create_org_profile("web3", "ipfs://org");
-    dispatcher.create_bootcamp(
-        "web3", "bootcamp1", "nft_uri", "NFT", "NFTSYM", 1, "ipfs://bootcamp1"
-    );
+    dispatcher
+        .create_bootcamp("web3", "bootcamp1", "nft_uri", "NFT", "NFTSYM", 1, "ipfs://bootcamp1");
     stop_cheat_caller_address(contract_address);
     start_cheat_caller_address(contract_address, student_address);
     dispatcher.register_for_bootcamp(owner_address, 0, "ipfs://student");
@@ -2238,9 +2238,8 @@ fn test_remove_bootcamp_state_cleanup() {
     let dispatcher = IAttenSysOrgDispatcher { contract_address };
     start_cheat_caller_address(contract_address, owner_address);
     dispatcher.create_org_profile("web3", "ipfs://org");
-    dispatcher.create_bootcamp(
-        "web3", "bootcamp1", "nft_uri", "NFT", "NFTSYM", 1, "ipfs://bootcamp1"
-    );
+    dispatcher
+        .create_bootcamp("web3", "bootcamp1", "nft_uri", "NFT", "NFTSYM", 1, "ipfs://bootcamp1");
     dispatcher.add_active_meet_link("meet", 0, false, owner_address);
     dispatcher.remove_bootcamp(0);
     // Should not panic, state should be cleaned
@@ -2264,7 +2263,8 @@ fn test_remove_non_existent_bootcamp() {
     dispatcher.remove_bootcamp(0);
 }
 
-// Additional edge and concurrency tests can be added as needed, e.g. for expiration, pending payments, etc.
+// Additional edge and concurrency tests can be added as needed, e.g. for expiration, pending
+// payments, etc.
 
 ///// Tier price tests /////
 


### PR DESCRIPTION
Closes #107 

## Changes Made:

- I added the functions to calculate price in strk, and to get strk price in usd from the oracle. These functions are identical to the ones in the AttensysCourse contract
- I added a field in the Bootcamp struct for price, and a field for funds. The price represents the price of the bootcamp, and the funds represents how much has been paid for the bootcamp
- I edited all the cases of bootcamp definition that had errors due to the new change I had made to the bootcamp struct. 
- I added a function to withdraw bootcamp funds, and implemented a lock until the bootcamp is ended.

### Withdraw function logic:
When the student pays, the student sends funds to the contract, and the contract holds these funds. Whenever the bootcamp owner tries to withdraw, the contract makes sure the bootcamp is ended, and then pays the owner the bootcamp funds, as recorded in its object.

- [x] The changes are covered by unit tests

### Note: 
The tests that involved payment such as the test for funds withdrawal and registration for paid bootcamp were ignored, hust as was done in the test for AttensysCourse

### Recommendation:
- I can add a can_withdraw function to the contract that returns a boolean for ease of use on the frontend on the buttons for withdrawal, or is_bootcamp_ended function can be used. The can_withdraw would be useful if there are other criteria for the funds to be withdrawn, such as suspension status for the bootcamp
- The token_address could also be made part of the contractstate by accepting it within the constructor, so that a mock token could be used for the tests. I doubt it will affect the pragma lib implementation. But the maintainer must have a reason for doing it the way he did.


ALWAYS A PLEASURE CONTRIBUTING!!!