### PR TITLE
tier-specific feature added to org contract

### DIFF
--- a/src/contracts/course/AttenSysCourse.cairo
+++ b/src/contracts/course/AttenSysCourse.cairo
@@ -66,10 +66,9 @@ pub trait IAttenSysCourse<TContractState> {
     fn get_fee_withdrawable_amount(self: @TContractState) -> u128;
     fn get_total_course_sales(self: @TContractState, user: ContractAddress) -> u128;
     fn review(ref self: TContractState, course_identifier: u128);
-    fn get_review_status(self: @TContractState, course_identifier: u128, user: ContractAddress) -> bool;
-
-
-     
+    fn get_review_status(
+        self: @TContractState, course_identifier: u128, user: ContractAddress,
+    ) -> bool;
 }
 
 //Todo, make a count of the total number of users that finished the course.
@@ -97,20 +96,22 @@ pub trait IERC20<TContractState> {
 
 #[starknet::contract]
 pub mod AttenSysCourse {
+    use attendsys::contracts::course::AttenSysCourse::{IERC20Dispatcher, IERC20DispatcherTrait};
     use core::starknet::storage::{
         Map, MutableVecTrait, StoragePathEntry, StoragePointerReadAccess, StoragePointerWriteAccess,
         Vec, VecTrait,
     };
     use core::starknet::syscalls::deploy_syscall;
-    use core::starknet::{ClassHash, ContractAddress, contract_address_const, get_caller_address, get_contract_address};
+    use core::starknet::{
+        ClassHash, ContractAddress, contract_address_const, get_caller_address,
+        get_contract_address,
+    };
     use openzeppelin::access::ownable::OwnableComponent;
     use openzeppelin::upgrades::UpgradeableComponent;
     use openzeppelin::upgrades::interface::IUpgradeable;
     use pragma_lib::abi::{IPragmaABIDispatcher, IPragmaABIDispatcherTrait};
     use pragma_lib::types::{AggregationMode, DataType, PragmaPricesResponse};
     use super::IAttenSysNftDispatcherTrait;
-    use attendsys::contracts::course::AttenSysCourse::{IERC20Dispatcher, IERC20DispatcherTrait};
-    
 
 
     component!(path: OwnableComponent, storage: ownable, event: OwnableEvent);
@@ -131,7 +132,8 @@ pub mod AttenSysCourse {
     const ORACLE_PRECISION: u128 = 100_000_000;
     const DECIMALS: u128 = 10_00_000_000_000_000_000; // 18 decimals
 
-    const STRK_CONTRACT_ADDRESS: felt252 = 0x04718f5a0Fc34cC1AF16A1cdee98fFB20C31f5cD61D6Ab07201858f4287c938D;
+    const STRK_CONTRACT_ADDRESS: felt252 =
+        0x04718f5a0Fc34cC1AF16A1cdee98fFB20C31f5cD61D6Ab07201858f4287c938D;
 
     #[event]
     #[derive(starknet::Event, Debug, Drop)]
@@ -263,11 +265,10 @@ pub mod AttenSysCourse {
         fee_value: u128,
         //withdrawable fee
         fee_withdrawable: u128,
-        // total course sales 
+        // total course sales
         total_course_sales: Map<ContractAddress, u128>,
-        // review status    
+        // review status
         course_review: Map<(ContractAddress, u128), bool>,
-
     }
     //find a way to keep track of all course identifiers for each owner.
     #[derive(Drop, Serde, starknet::Store)]
@@ -328,7 +329,7 @@ pub mod AttenSysCourse {
                 current_creator_info.number_of_courses += 1;
                 current_creator_info.creator_status = true;
             }
- 
+
             let mut course_call_data: Course = Course {
                 owner: owner_,
                 course_identifier: current_identifier,
@@ -425,12 +426,20 @@ pub mod AttenSysCourse {
             let amount_usd = self
                 .specific_course_info_with_identifer
                 .entry(course_identifier)
-                .price.read();
+                .price
+                .read();
 
             let amount_in_strk = self.calculate_course_price_in_strk(amount_usd);
-            
-            let erc20_dispatcher = IERC20Dispatcher { contract_address: STRK_CONTRACT_ADDRESS.try_into().unwrap()};
-            erc20_dispatcher.transferFrom(get_caller_address(), get_contract_address(), (amount_in_strk * DECIMALS).into());
+
+            let erc20_dispatcher = IERC20Dispatcher {
+                contract_address: STRK_CONTRACT_ADDRESS.try_into().unwrap(),
+            };
+            erc20_dispatcher
+                .transferFrom(
+                    get_caller_address(),
+                    get_contract_address(),
+                    (amount_in_strk * DECIMALS).into(),
+                );
 
             self.user_to_course_status.entry((caller, course_identifier)).write(true);
             let derived_course = self
@@ -438,13 +447,15 @@ pub mod AttenSysCourse {
                 .entry(course_identifier)
                 .read();
             let course_owner = derived_course.owner;
-            self.withdrawable_amount
+            self
+                .withdrawable_amount
                 .entry(course_owner)
                 .write(self.withdrawable_amount.entry(course_owner).read() + amount_in_strk.into());
             self.user_courses.entry(caller).append().write(derived_course);
-            self.total_course_sales.entry(course_owner).write(
-                self.total_course_sales.entry(course_owner).read() + 1,
-            );
+            self
+                .total_course_sales
+                .entry(course_owner)
+                .write(self.total_course_sales.entry(course_owner).read() + 1);
             self.emit(AcquiredCourse { course_identifier, owner: course_owner, candidate: caller });
         }
 
@@ -577,16 +588,24 @@ pub mod AttenSysCourse {
             //     copy.append(self.all_course_info.at(i).read());
             // }
             //run a loop to check if course ID exists in all course info vece, if it does, replace
-            //the uris.        
+            //the uris.
             for i in 0..self.all_course_info.len() {
-                    if self.all_course_info.at(i).read().course_identifier == course_identifier {
-                        self.all_course_info.at(i).uri.write(new_course_uri.clone());
-                        self.all_course_info.at(i).course_ipfs_uri.write(new_course_uri.clone());
-                        self.specific_course_info_with_identifer.entry(course_identifier).course_ipfs_uri.write(new_course_uri.clone());
-                        self.specific_course_info_with_identifer.entry(course_identifier).uri.write(new_course_uri.clone());
-                        break;
-                    };
-            };         
+                if self.all_course_info.at(i).read().course_identifier == course_identifier {
+                    self.all_course_info.at(i).uri.write(new_course_uri.clone());
+                    self.all_course_info.at(i).course_ipfs_uri.write(new_course_uri.clone());
+                    self
+                        .specific_course_info_with_identifer
+                        .entry(course_identifier)
+                        .course_ipfs_uri
+                        .write(new_course_uri.clone());
+                    self
+                        .specific_course_info_with_identifer
+                        .entry(course_identifier)
+                        .uri
+                        .write(new_course_uri.clone());
+                    break;
+                };
+            }
             //run a loop to update the creator content storage data
             let mut i: u64 = 0;
             let vec_len = self.creator_to_all_content.entry(owner_).len();
@@ -622,7 +641,7 @@ pub mod AttenSysCourse {
                 );
         }
 
-  
+
         fn finish_course_claim_certification(ref self: ContractState, course_identifier: u128) {
             //only check for accessment score. that is if there's assesment
             //todo : verifier check, get a value from frontend, confirm the hash if it matches with
@@ -886,10 +905,12 @@ pub mod AttenSysCourse {
                 }
             }
         }
-        
-        fn creator_withdraw(ref self: ContractState, amount: u128){
+
+        fn creator_withdraw(ref self: ContractState, amount: u128) {
             let caller = get_caller_address();
-            let token_dispatcher = IERC20Dispatcher { contract_address: STRK_CONTRACT_ADDRESS.try_into().unwrap(), };
+            let token_dispatcher = IERC20Dispatcher {
+                contract_address: STRK_CONTRACT_ADDRESS.try_into().unwrap(),
+            };
             let contract_token_balance = token_dispatcher.balanceOf(get_contract_address());
             assert(self.withdrawable_amount.entry(caller).read() > 0, 'not admin');
             assert(amount <= contract_token_balance, 'Not enough balance');
@@ -898,57 +919,63 @@ pub mod AttenSysCourse {
             let fee = amount * self.fee_value.read() / 100;
             let withdrawable_less_fee = amount - fee;
             self.fee_withdrawable.write(self.fee_withdrawable.read() + fee);
-            let has_transferred = token_dispatcher.transfer(recipient: caller, amount: (withdrawable_less_fee * DECIMALS).into());
+            let has_transferred = token_dispatcher
+                .transfer(recipient: caller, amount: (withdrawable_less_fee * DECIMALS).into());
             if has_transferred {
-                self.withdrawable_amount.entry(caller).write(self.withdrawable_amount.entry(caller).read() - amount);
-            }            
+                self
+                    .withdrawable_amount
+                    .entry(caller)
+                    .write(self.withdrawable_amount.entry(caller).read() - amount);
+            }
         }
-        
-        fn init_fee_percent(ref self: ContractState, fee: u128){
+
+        fn init_fee_percent(ref self: ContractState, fee: u128) {
             assert(fee > 0, 'fee cannot be zero');
             assert(fee <= 100, 'fee cannot be > 100');
             assert(get_caller_address() == self.admin.read(), 'unauthorized caller');
             self.fee_value.write(fee);
         }
-        
-        fn admin_withdrawables(ref self: ContractState, amount: u128){
+
+        fn admin_withdrawables(ref self: ContractState, amount: u128) {
             assert(amount > 0, 'amount cannot be zero');
             assert(amount <= self.fee_withdrawable.read(), 'Not enough balance');
             assert(get_caller_address() == self.admin.read(), 'unauthorized caller');
-            let token_dispatcher = IERC20Dispatcher { contract_address: STRK_CONTRACT_ADDRESS.try_into().unwrap(), };
-            let has_transferred = token_dispatcher.transfer(recipient: get_caller_address(), amount: (amount * DECIMALS).into());
+            let token_dispatcher = IERC20Dispatcher {
+                contract_address: STRK_CONTRACT_ADDRESS.try_into().unwrap(),
+            };
+            let has_transferred = token_dispatcher
+                .transfer(recipient: get_caller_address(), amount: (amount * DECIMALS).into());
             if has_transferred {
                 self.fee_withdrawable.write(self.fee_withdrawable.read() - amount);
             }
         }
-        fn get_creator_withdrawable_amount(self: @ContractState, user: ContractAddress) -> u128{
+        fn get_creator_withdrawable_amount(self: @ContractState, user: ContractAddress) -> u128 {
             self.withdrawable_amount.entry(user).read()
         }
-        fn get_fee_withdrawable_amount(self: @ContractState) -> u128{
+        fn get_fee_withdrawable_amount(self: @ContractState) -> u128 {
             self.fee_withdrawable.read()
         }
-        fn get_total_course_sales(self: @ContractState, user: ContractAddress) -> u128{
+        fn get_total_course_sales(self: @ContractState, user: ContractAddress) -> u128 {
             self.total_course_sales.read(user)
         }
 
-         fn review(ref self: ContractState, course_identifier: u128){
+        fn review(ref self: ContractState, course_identifier: u128) {
             let caller = get_caller_address();
             assert(
                 self.user_to_course_status.entry((caller, course_identifier)).read(),
                 'not acquired',
             );
             assert(
-                !self.course_review.entry((caller, course_identifier)).read(),
-                'already reviewed',
+                !self.course_review.entry((caller, course_identifier)).read(), 'already reviewed',
             );
             self.course_review.entry((caller, course_identifier)).write(true);
-         }
-
-        fn get_review_status(self: @ContractState, course_identifier: u128, user: ContractAddress) -> bool{
-            self.course_review.entry((user, course_identifier)).read()
         }
 
-
+        fn get_review_status(
+            self: @ContractState, course_identifier: u128, user: ContractAddress,
+        ) -> bool {
+            self.course_review.entry((user, course_identifier)).read()
+        }
     }
 
     #[generate_trait]

--- a/src/contracts/org/AttenSysOrg.cairo
+++ b/src/contracts/org/AttenSysOrg.cairo
@@ -131,6 +131,12 @@ pub trait IAttenSysOrg<TContractState> {
         self: @TContractState, org: ContractAddress, bootcamp_id: u64, student: ContractAddress,
     ) -> bool;
     fn upgrade(ref self: TContractState, new_class_hash: ClassHash);
+    fn set_tier_price(ref self: TContractState, tier: u256, price: u256);
+    fn change_tier(
+        ref self: TContractState, org_address: ContractAddress, new_tier: AttenSysOrg::Tier,
+    );
+    fn get_tier_price(self: @TContractState, tier: u256) -> u256;
+    fn get_tier(self: @TContractState, org: ContractAddress) -> AttenSysOrg::Tier;
 }
 
 // Events
@@ -220,6 +226,8 @@ pub mod AttenSysOrg {
         student_address_to_specific_bootcamp: Map<
             (ContractAddress, ContractAddress), Vec<RegisteredBootcamp>,
         >,
+        //maps tier to price
+        tier_price: Map<u256, u256>,
         //maps org to bootcamp to classID
         bootcamp_class_data_id: Map<(ContractAddress, u64), Vec<u64>>,
         //saves all certifed student for each bootcamp
@@ -241,6 +249,16 @@ pub mod AttenSysOrg {
         pub number_of_all_bootcamps: u256,
         pub org_ipfs_uri: ByteArray,
         pub total_sponsorship_fund: u256,
+        pub tier: Tier,
+    }
+
+
+    #[allow(starknet::store_no_default_variant)]
+    #[derive(Drop, Serde, starknet::Store, Copy, PartialEq)]
+    pub enum Tier {
+        Free,
+        Premium,
+        PremiumPlus,
     }
 
     #[derive(Drop, Serde, starknet::Store)]
@@ -322,6 +340,8 @@ pub mod AttenSysOrg {
         SponsorshipFundWithdrawn: SponsorshipFundWithdrawn,
         OrganizationSuspended: OrganizationSuspended,
         BootCampSuspended: BootCampSuspended,
+        SetTierPrice: SetTierPrice,
+        ChangeTier: ChangeTier,
         #[flat]
         OwnableEvent: OwnableComponent::Event,
         #[flat]
@@ -458,6 +478,18 @@ pub mod AttenSysOrg {
         pub suspended: bool,
     }
 
+    #[derive(Drop, starknet::Event)]
+    pub struct SetTierPrice {
+        pub tier: u256,
+        pub price: u256,
+    }
+
+    #[derive(Drop, starknet::Event)]
+    pub struct ChangeTier {
+        pub org_address: ContractAddress,
+        pub new_tier: Tier,
+    }
+
     #[constructor]
     fn constructor(
         ref self: ContractState,
@@ -496,6 +528,7 @@ pub mod AttenSysOrg {
                     number_of_all_bootcamps: 0,
                     org_ipfs_uri: org_ipfs_uri.clone(),
                     total_sponsorship_fund: 0,
+                    tier: Tier::Free,
                 };
 
                 let uri = org_ipfs_uri.clone();
@@ -514,6 +547,7 @@ pub mod AttenSysOrg {
                             number_of_all_bootcamps: 0,
                             org_ipfs_uri: org_ipfs_uri,
                             total_sponsorship_fund: 0,
+                            tier: Tier::Free,
                         },
                     );
                 let orginization_name = org_name.clone();
@@ -1469,6 +1503,32 @@ pub mod AttenSysOrg {
 
             // Replace the class hash upgrading the contract
             self.upgradeable.upgrade(new_class_hash);
+        }
+
+        fn set_tier_price(ref self: ContractState, tier: u256, price: u256) {
+            // This function can only be called by the owner
+            only_admin(ref self);
+            assert(tier == 0 || tier == 1 || tier == 2, 'Invalid tier');
+            self.tier_price.entry(tier).write(price);
+            self.emit(SetTierPrice { tier, price });
+        }
+
+        fn get_tier_price(self: @ContractState, tier: u256) -> u256 {
+            self.tier_price.entry(tier).read()
+        }
+        fn change_tier(ref self: ContractState, org_address: ContractAddress, new_tier: Tier) {
+            assert(org_address != self.zero_address(), 'zero address not allowed');
+            assert(org_address == get_caller_address(), 'unauthorized caller');
+            let mut org_info: Organization = self.organization_info.entry(org_address).read();
+            assert(org_info.tier != new_tier, 'same tier');
+            org_info.tier = new_tier;
+            self.organization_info.entry(org_address).write(org_info);
+            self.emit(ChangeTier { org_address, new_tier });
+        }
+
+        fn get_tier(self: @ContractState, org: ContractAddress) -> Tier {
+            let org_info: Organization = self.organization_info.entry(org).read();
+            org_info.tier
         }
     }
 

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -5,7 +5,7 @@ pub mod contracts {
     pub mod event {
         pub mod AttenSysEvent;
     }
-    pub mod attensysnft{
+    pub mod attensysnft {
         pub mod AttenSysNft;
     }
     pub mod org {

--- a/tests/test_attensys_course.cairo
+++ b/tests/test_attensys_course.cairo
@@ -1,12 +1,12 @@
 use attendsys::contracts::course::AttenSysCourse::{
     IAttenSysCourseDispatcher, IAttenSysCourseDispatcherTrait,
 };
+use openzeppelin::token::erc20::interface::{ERC20ABIDispatcher, ERC20ABIDispatcherTrait};
 use snforge_std::{
     ContractClassTrait, DeclareResultTrait, declare, start_cheat_caller_address,
-    stop_cheat_caller_address
+    stop_cheat_caller_address,
 };
 use starknet::{ClassHash, ContractAddress, contract_address_const};
-use openzeppelin::token::erc20::interface::{ERC20ABIDispatcher, ERC20ABIDispatcherTrait};
 
 
 fn zero_address() -> ContractAddress {
@@ -271,25 +271,33 @@ fn test_course_purchase() {
     let name: ByteArray = "Test Course";
     let symbol: ByteArray = "TC";
 
-    const STRK_CONTRACT_ADDRESS: felt252 = 0x04718f5a0Fc34cC1AF16A1cdee98fFB20C31f5cD61D6Ab07201858f4287c938D;
+    const STRK_CONTRACT_ADDRESS: felt252 =
+        0x04718f5a0Fc34cC1AF16A1cdee98fFB20C31f5cD61D6Ab07201858f4287c938D;
 
     start_cheat_caller_address(contract_address, owner);
     attensys_course_contract.create_course(owner, true, base_uri, name, symbol, base_uri_2, 10);
     stop_cheat_caller_address(contract_address);
 
-     //approve contract to spend token
-     start_cheat_caller_address(STRK_CONTRACT_ADDRESS.try_into().unwrap(), student.try_into().unwrap());
-     let token_dispatcher = ERC20ABIDispatcher { contract_address: STRK_CONTRACT_ADDRESS.try_into().unwrap(), };
-     let balance = token_dispatcher.balance_of(student.try_into().unwrap());
+    //approve contract to spend token
+    start_cheat_caller_address(
+        STRK_CONTRACT_ADDRESS.try_into().unwrap(), student.try_into().unwrap(),
+    );
+    let token_dispatcher = ERC20ABIDispatcher {
+        contract_address: STRK_CONTRACT_ADDRESS.try_into().unwrap(),
+    };
+    let balance = token_dispatcher.balance_of(student.try_into().unwrap());
     println!("student balance before purchase: {}", balance);
-     let first_balance = token_dispatcher.balance_of(contract_address);
-     println!("contract balance before purchase: {}", first_balance);
-     token_dispatcher.approve(contract_address, 500000000000000000000000000);
-     stop_cheat_caller_address(STRK_CONTRACT_ADDRESS.try_into().unwrap());
-   
+    let first_balance = token_dispatcher.balance_of(contract_address);
+    println!("contract balance before purchase: {}", first_balance);
+    token_dispatcher.approve(contract_address, 500000000000000000000000000);
+    stop_cheat_caller_address(STRK_CONTRACT_ADDRESS.try_into().unwrap());
+
     start_cheat_caller_address(contract_address, student.try_into().unwrap());
     attensys_course_contract.acquire_a_course(1);
-    assert(attensys_course_contract.is_user_taking_course(student.try_into().unwrap(), 1), 'not acquired');
+    assert(
+        attensys_course_contract.is_user_taking_course(student.try_into().unwrap(), 1),
+        'not acquired',
+    );
     let second_balance = token_dispatcher.balance_of(contract_address);
     println!("contract balance after purchase: {}", second_balance);
     stop_cheat_caller_address(contract_address);
@@ -309,59 +317,75 @@ fn test_purchase_course_completions_n_withdrawals() {
     attensys_course_contract.init_fee_percent(10);
     stop_cheat_caller_address(contract_address);
 
-
     let owner: felt252 = 0x0330c28cd779dE4d895c2B99C3878DD6CBB30C3Da3be117e83b9CB3b947E5A1A;
-    let student1:felt252 = 0x05Bf9E38B116B37A8249a4cd041D402903a5E8a67C1a99d2D336ac7bd8B4034e;
+    let student1: felt252 = 0x05Bf9E38B116B37A8249a4cd041D402903a5E8a67C1a99d2D336ac7bd8B4034e;
     let student2: felt252 = 0x047EC7F6120Eb1aD7d037B40c37E9dDDfC5f3C7D6f63d49BE9683D278ccfF0ec;
     let base_uri: ByteArray = "https://example.com/";
     let base_uri_2: ByteArray = "https://example.com/";
     let name: ByteArray = "Test Course";
     let symbol: ByteArray = "TC";
 
-    const STRK_CONTRACT_ADDRESS: felt252 = 0x04718f5a0Fc34cC1AF16A1cdee98fFB20C31f5cD61D6Ab07201858f4287c938D;
+    const STRK_CONTRACT_ADDRESS: felt252 =
+        0x04718f5a0Fc34cC1AF16A1cdee98fFB20C31f5cD61D6Ab07201858f4287c938D;
 
     let course_creator_address: ContractAddress = contract_address_const::<'course_creator'>();
     start_cheat_caller_address(contract_address, course_creator_address);
-    attensys_course_contract.create_course(course_creator_address, true, base_uri, name, symbol, base_uri_2, 1);
+    attensys_course_contract
+        .create_course(course_creator_address, true, base_uri, name, symbol, base_uri_2, 1);
 
     let initial_count = attensys_course_contract.get_total_course_completions(1);
     assert(initial_count == 0, 'initial count should be 0');
 
-     //approve contract to spend token
-     start_cheat_caller_address(STRK_CONTRACT_ADDRESS.try_into().unwrap(), student1.try_into().unwrap());
-     let token_dispatcher = ERC20ABIDispatcher { contract_address: STRK_CONTRACT_ADDRESS.try_into().unwrap(), };
-     let balance = token_dispatcher.balance_of(student1.try_into().unwrap());
-     println!("student1 balance before purchase: {}", balance);
-     let first_contract_balance = token_dispatcher.balance_of(contract_address);
-     println!("contract balance before student 1 purchase: {}", first_contract_balance);
-     token_dispatcher.approve(contract_address, 50000000000000000000000000);
-     stop_cheat_caller_address(STRK_CONTRACT_ADDRESS.try_into().unwrap());
+    //approve contract to spend token
+    start_cheat_caller_address(
+        STRK_CONTRACT_ADDRESS.try_into().unwrap(), student1.try_into().unwrap(),
+    );
+    let token_dispatcher = ERC20ABIDispatcher {
+        contract_address: STRK_CONTRACT_ADDRESS.try_into().unwrap(),
+    };
+    let balance = token_dispatcher.balance_of(student1.try_into().unwrap());
+    println!("student1 balance before purchase: {}", balance);
+    let first_contract_balance = token_dispatcher.balance_of(contract_address);
+    println!("contract balance before student 1 purchase: {}", first_contract_balance);
+    token_dispatcher.approve(contract_address, 50000000000000000000000000);
+    stop_cheat_caller_address(STRK_CONTRACT_ADDRESS.try_into().unwrap());
 
-
-     start_cheat_caller_address(STRK_CONTRACT_ADDRESS.try_into().unwrap(), student2.try_into().unwrap());
-     let token_dispatcher = ERC20ABIDispatcher { contract_address: STRK_CONTRACT_ADDRESS.try_into().unwrap(), };
-     let balance_two = token_dispatcher.balance_of(student2.try_into().unwrap());
-     println!("student2 balance before purchase: {}", balance_two);
-     let second_contract_balance = token_dispatcher.balance_of(contract_address);
-     println!("contract balance before student 2 purchase: {}", second_contract_balance);
-     token_dispatcher.approve(contract_address, 50000000000000000000000000);
-     stop_cheat_caller_address(STRK_CONTRACT_ADDRESS.try_into().unwrap());
-
+    start_cheat_caller_address(
+        STRK_CONTRACT_ADDRESS.try_into().unwrap(), student2.try_into().unwrap(),
+    );
+    let token_dispatcher = ERC20ABIDispatcher {
+        contract_address: STRK_CONTRACT_ADDRESS.try_into().unwrap(),
+    };
+    let balance_two = token_dispatcher.balance_of(student2.try_into().unwrap());
+    println!("student2 balance before purchase: {}", balance_two);
+    let second_contract_balance = token_dispatcher.balance_of(contract_address);
+    println!("contract balance before student 2 purchase: {}", second_contract_balance);
+    token_dispatcher.approve(contract_address, 50000000000000000000000000);
+    stop_cheat_caller_address(STRK_CONTRACT_ADDRESS.try_into().unwrap());
 
     start_cheat_caller_address(contract_address, student1.try_into().unwrap());
     attensys_course_contract.acquire_a_course(1);
-    assert(attensys_course_contract.is_user_taking_course(student1.try_into().unwrap(), 1), 'not acquired');
+    assert(
+        attensys_course_contract.is_user_taking_course(student1.try_into().unwrap(), 1),
+        'not acquired',
+    );
     let new_balance_first = token_dispatcher.balance_of(contract_address);
     let review_status = attensys_course_contract.get_review_status(1, student1.try_into().unwrap());
     assert(!review_status, 'should be false');
     attensys_course_contract.review(1);
-    assert(attensys_course_contract.get_review_status(1, student1.try_into().unwrap()), 'should be true');
+    assert(
+        attensys_course_contract.get_review_status(1, student1.try_into().unwrap()),
+        'should be true',
+    );
     println!("contract balance after student 1 purchase: {}", new_balance_first);
     stop_cheat_caller_address(contract_address);
 
     start_cheat_caller_address(contract_address, student2.try_into().unwrap());
     attensys_course_contract.acquire_a_course(1);
-    assert(attensys_course_contract.is_user_taking_course(student2.try_into().unwrap(), 1), 'not acquired');
+    assert(
+        attensys_course_contract.is_user_taking_course(student2.try_into().unwrap(), 1),
+        'not acquired',
+    );
     let new_balance_second = token_dispatcher.balance_of(contract_address);
     println!("contract balance after student 2 purchase: {}", new_balance_second);
     stop_cheat_caller_address(contract_address);
@@ -383,25 +407,37 @@ fn test_purchase_course_completions_n_withdrawals() {
     start_cheat_caller_address(contract_address, course_creator_address);
     let balance_before_creator_withdrawal = token_dispatcher.balance_of(course_creator_address);
     println!("contract balance before creator withdrawing: {}", balance_before_creator_withdrawal);
-    let creator_withdrawable = attensys_course_contract.get_creator_withdrawable_amount(course_creator_address);
+    let creator_withdrawable = attensys_course_contract
+        .get_creator_withdrawable_amount(course_creator_address);
     println!("creator withdrawable amount: {}", creator_withdrawable);
     attensys_course_contract.creator_withdraw(creator_withdrawable.try_into().unwrap());
     let balance_after_creator_withdrawal = token_dispatcher.balance_of(contract_address);
-    // println!("contract balance after creator withdrawing 20 strk minus 2 strk fee: {}", balance_after_creator_withdrawal);
-    println!("contract balance after creator withdrawing all strk minus fee: {}", balance_after_creator_withdrawal);
+    // println!("contract balance after creator withdrawing 20 strk minus 2 strk fee: {}",
+    // balance_after_creator_withdrawal);
+    println!(
+        "contract balance after creator withdrawing all strk minus fee: {}",
+        balance_after_creator_withdrawal,
+    );
     stop_cheat_caller_address(contract_address);
 
-    start_cheat_caller_address(contract_address, contract_owner_address.try_into().unwrap()); 
-    let balance_before_admin_start_withdrawal = token_dispatcher.balance_of(contract_address); 
-    println!("contract balance before admin withdrawing all generated in fee: {}", balance_before_admin_start_withdrawal);
-    attensys_course_contract.admin_withdrawables(1);    
+    start_cheat_caller_address(contract_address, contract_owner_address.try_into().unwrap());
+    let balance_before_admin_start_withdrawal = token_dispatcher.balance_of(contract_address);
+    println!(
+        "contract balance before admin withdrawing all generated in fee: {}",
+        balance_before_admin_start_withdrawal,
+    );
+    attensys_course_contract.admin_withdrawables(1);
     let balance_after_admin_withdrawal = token_dispatcher.balance_of(contract_address);
     let balance_after_creator_withdrawal = token_dispatcher.balance_of(course_creator_address);
-    println!("contract balance after admin withdrawing all generated in fee: {}", balance_after_admin_withdrawal);
-    println!("contract balance after creator withdrawing all: {}", balance_after_creator_withdrawal);
-    
-    stop_cheat_caller_address(contract_address);
+    println!(
+        "contract balance after admin withdrawing all generated in fee: {}",
+        balance_after_admin_withdrawal,
+    );
+    println!(
+        "contract balance after creator withdrawing all: {}", balance_after_creator_withdrawal,
+    );
 
+    stop_cheat_caller_address(contract_address);
 }
 
 

--- a/tests/test_attensys_event.cairo
+++ b/tests/test_attensys_event.cairo
@@ -1,4 +1,6 @@
-use attendsys::contracts::event::AttenSysEvent::{IAttenSysEventDispatcher, IAttenSysEventDispatcherTrait};
+use attendsys::contracts::event::AttenSysEvent::{
+    IAttenSysEventDispatcher, IAttenSysEventDispatcherTrait,
+};
 use snforge_std::{
     ContractClassTrait, DeclareResultTrait, declare, start_cheat_caller_address,
     stop_cheat_caller_address, test_address,

--- a/tests/test_attensys_sponsored_event_funds_flow.cairo
+++ b/tests/test_attensys_sponsored_event_funds_flow.cairo
@@ -1,4 +1,6 @@
-use attendsys::contracts::event::AttenSysEvent::{IAttenSysEventDispatcher, IAttenSysEventDispatcherTrait};
+use attendsys::contracts::event::AttenSysEvent::{
+    IAttenSysEventDispatcher, IAttenSysEventDispatcherTrait,
+};
 use attendsys::contracts::sponsor::AttenSysSponsor::{
     AttenSysSponsor, IAttenSysSponsorDispatcher, IAttenSysSponsorDispatcherTrait,
 };

--- a/tests/test_attensys_upgradeability.cairo
+++ b/tests/test_attensys_upgradeability.cairo
@@ -2,7 +2,9 @@ use attendsys::contracts::course::AttenSysCourse;
 use attendsys::contracts::course::AttenSysCourse::{
     IAttenSysCourseDispatcher, IAttenSysCourseDispatcherTrait,
 };
-use attendsys::contracts::event::AttenSysEvent::{IAttenSysEventDispatcher, IAttenSysEventDispatcherTrait};
+use attendsys::contracts::event::AttenSysEvent::{
+    IAttenSysEventDispatcher, IAttenSysEventDispatcherTrait,
+};
 use attendsys::contracts::org::AttenSysOrg::{IAttenSysOrgDispatcher, IAttenSysOrgDispatcherTrait};
 use snforge_std::{
     ContractClassTrait, DeclareResultTrait, declare, start_cheat_caller_address,

--- a/tests/test_pricefeed.cairo
+++ b/tests/test_pricefeed.cairo
@@ -121,7 +121,7 @@ fn test_pricefeed_work_with_course_creation() {
     // get_all_courses_info
     let courses = attensys_course_contract.get_all_courses_info();
     assert(courses.len() == 1, 'Course should be created');
-   
+
     // create a course with price 0 USD
     let price_2: u128 = 0; //0 USD
     start_cheat_caller_address(course_contract, owner_two);
@@ -153,7 +153,7 @@ fn test_update_price() {
     };
     let oracle_response = oracle.get_data(asset_data_type, AggregationMode::Median(()));
     let price_of_strk_usd = oracle_response.price;
-    let (c, hash) = deploy_nft_contract("AttenSysNft");                                                   
+    let (c, hash) = deploy_nft_contract("AttenSysNft");
     let course_contract = deploy_contract("AttenSysCourse", hash);
     let attensys_course_contract = IAttenSysCourseDispatcher { contract_address: course_contract };
     assert(


### PR DESCRIPTION
The tier-specific feature implementation has the following:
- Added to an organization struct and the default is the Tier::Free for newly created organization.
- Organization owners can change their tier (either upgrade or downgrade with the change_tier function)
- Contract admin can set the prices for each tiers
- Three tests were added to verify this feature and a one liner to existing test to verify the default tier state of an organization.
- The "scarb fmt" cmd formatted for the AttensysOrg contract and others.

All implementation fulfils the #108 issue.